### PR TITLE
Update app-sdk-ios.md

### DIFF
--- a/intune/app-sdk-ios.md
+++ b/intune/app-sdk-ios.md
@@ -204,7 +204,7 @@ If your app already uses ADAL, the following configurations are required:
 
 3. Also under the **IntuneMAMSettings** dictionary with the key name `ADALRedirectUri`, specify the redirect URI to be used for ADAL calls. Alternatively, you could specify `ADALRedirectScheme` instead, if the application's redirect URI is in the format `scheme://bundle_id`.
 
-Additionally, apps can override these Azure AD settings at runtime. To do this, simply set the `aadAuthorityUriOverride`, `aadClientIdOverride`, and `aadRedirectUriOverride` properties on the `IntuneMAMPolicyManager` instance.
+Additionally, apps can override these Azure AD settings at runtime. To do this, simply set the `aadAuthorityUriOverride`, `aadClientIdOverride`, and `aadRedirectUriOverride` properties on `IntuneMAMSettings`.
 
 4. Ensure the steps to give your iOS app permissions to the app protection policy (APP) service are followed. Use the instructions in the [getting started with the Intune SDK guide](https://docs.microsoft.com/intune/app-sdk-get-started#next-steps-after-integration) under "Give your app access to the Intune app protection service (optional)".  
 


### PR DESCRIPTION
Since `aadRedirectUriOverride` `aadClientIdOverride` and `aadRedirectUriOverride` from `IntuneMAMPolicyManager` are marked as deprecated in the current implementation, this should be replace by setting the following values on `IntuneMAMSettings` as suggested in `IntuneMAMPolicyManager.h`